### PR TITLE
Refactor Prisma schema and guards

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,3 @@
 DATABASE_URL="postgresql://USER:PASSWORD@localhost:5432/saas_db"
 JWT_SECRET="change_this_secret"
+TENANT_HEADER_NAME="x-tenant-id"

--- a/prisma/migrations/00000000_init/migration.sql
+++ b/prisma/migrations/00000000_init/migration.sql
@@ -1,6 +1,10 @@
 -- CreateEnum
 CREATE TYPE "Role" AS ENUM ('SUPER_ADMIN', 'SITE_OWNER', 'OPERATOR', 'USER');
+
+-- CreateEnum
 CREATE TYPE "SitePlanStatus" AS ENUM ('ACTIVE', 'CANCELED', 'EXPIRED');
+
+-- CreateEnum
 CREATE TYPE "PaymentStatus" AS ENUM ('PENDING', 'PAID', 'FAILED');
 
 -- CreateTable
@@ -11,6 +15,7 @@ CREATE TABLE "User" (
     "role" "Role" NOT NULL DEFAULT 'USER',
     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "updatedAt" TIMESTAMP(3) NOT NULL,
+
     CONSTRAINT "User_pkey" PRIMARY KEY ("id")
 );
 
@@ -21,6 +26,7 @@ CREATE TABLE "Site" (
     "ownerId" TEXT NOT NULL,
     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "updatedAt" TIMESTAMP(3) NOT NULL,
+
     CONSTRAINT "Site_pkey" PRIMARY KEY ("id")
 );
 
@@ -31,6 +37,7 @@ CREATE TABLE "Plan" (
     "price" DOUBLE PRECISION NOT NULL,
     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "updatedAt" TIMESTAMP(3) NOT NULL,
+
     CONSTRAINT "Plan_pkey" PRIMARY KEY ("id")
 );
 
@@ -41,14 +48,19 @@ CREATE TABLE "Feature" (
     "description" TEXT,
     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "updatedAt" TIMESTAMP(3) NOT NULL,
+
     CONSTRAINT "Feature_pkey" PRIMARY KEY ("id")
 );
 
 -- CreateTable
 CREATE TABLE "PlanFeature" (
+    "id" TEXT NOT NULL,
     "planId" TEXT NOT NULL,
     "featureId" TEXT NOT NULL,
-    CONSTRAINT "PlanFeature_pkey" PRIMARY KEY ("planId", "featureId")
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "PlanFeature_pkey" PRIMARY KEY ("id")
 );
 
 -- CreateTable
@@ -61,6 +73,7 @@ CREATE TABLE "SitePlan" (
     "status" "SitePlanStatus" NOT NULL DEFAULT 'ACTIVE',
     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "updatedAt" TIMESTAMP(3) NOT NULL,
+
     CONSTRAINT "SitePlan_pkey" PRIMARY KEY ("id")
 );
 
@@ -73,6 +86,7 @@ CREATE TABLE "SiteFeature" (
     "expiresAt" TIMESTAMP(3),
     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "updatedAt" TIMESTAMP(3) NOT NULL,
+
     CONSTRAINT "SiteFeature_pkey" PRIMARY KEY ("id")
 );
 
@@ -85,6 +99,7 @@ CREATE TABLE "Theme" (
     "assetsUrl" TEXT NOT NULL,
     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "updatedAt" TIMESTAMP(3) NOT NULL,
+
     CONSTRAINT "Theme_pkey" PRIMARY KEY ("id")
 );
 
@@ -94,6 +109,9 @@ CREATE TABLE "SiteTheme" (
     "siteId" TEXT NOT NULL,
     "themeId" TEXT NOT NULL,
     "activatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
     CONSTRAINT "SiteTheme_pkey" PRIMARY KEY ("id")
 );
 
@@ -101,47 +119,90 @@ CREATE TABLE "SiteTheme" (
 CREATE TABLE "Payment" (
     "id" TEXT NOT NULL,
     "siteId" TEXT NOT NULL,
-    "sitePlanId" TEXT,
+    "sitePlanId" TEXT NOT NULL,
     "amount" DOUBLE PRECISION NOT NULL,
-    "currency" TEXT NOT NULL DEFAULT 'USD',
+    "currency" TEXT NOT NULL,
     "status" "PaymentStatus" NOT NULL DEFAULT 'PENDING',
     "transactionDate" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "metadata" JSONB,
     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "updatedAt" TIMESTAMP(3) NOT NULL,
+
     CONSTRAINT "Payment_pkey" PRIMARY KEY ("id")
 );
 
 -- CreateIndex
 CREATE UNIQUE INDEX "User_email_key" ON "User"("email");
+
+-- CreateIndex
 CREATE INDEX "Site_ownerId_idx" ON "Site"("ownerId");
+
+-- CreateIndex
 CREATE UNIQUE INDEX "Feature_name_key" ON "Feature"("name");
+
+-- CreateIndex
 CREATE INDEX "PlanFeature_planId_idx" ON "PlanFeature"("planId");
+
+-- CreateIndex
 CREATE INDEX "PlanFeature_featureId_idx" ON "PlanFeature"("featureId");
+
+-- CreateIndex
 CREATE INDEX "SitePlan_siteId_idx" ON "SitePlan"("siteId");
+
+-- CreateIndex
 CREATE INDEX "SitePlan_planId_idx" ON "SitePlan"("planId");
+
+-- CreateIndex
 CREATE INDEX "SiteFeature_siteId_idx" ON "SiteFeature"("siteId");
+
+-- CreateIndex
 CREATE INDEX "SiteFeature_featureId_idx" ON "SiteFeature"("featureId");
+
+-- CreateIndex
 CREATE UNIQUE INDEX "Theme_key_key" ON "Theme"("key");
+
+-- CreateIndex
 CREATE INDEX "SiteTheme_siteId_idx" ON "SiteTheme"("siteId");
+
+-- CreateIndex
 CREATE INDEX "SiteTheme_themeId_idx" ON "SiteTheme"("themeId");
+
+-- CreateIndex
 CREATE INDEX "Payment_siteId_idx" ON "Payment"("siteId");
+
+-- CreateIndex
 CREATE INDEX "Payment_sitePlanId_idx" ON "Payment"("sitePlanId");
 
 -- AddForeignKey
 ALTER TABLE "Site" ADD CONSTRAINT "Site_ownerId_fkey" FOREIGN KEY ("ownerId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
 
+-- AddForeignKey
 ALTER TABLE "PlanFeature" ADD CONSTRAINT "PlanFeature_planId_fkey" FOREIGN KEY ("planId") REFERENCES "Plan"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
 ALTER TABLE "PlanFeature" ADD CONSTRAINT "PlanFeature_featureId_fkey" FOREIGN KEY ("featureId") REFERENCES "Feature"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
 
+-- AddForeignKey
 ALTER TABLE "SitePlan" ADD CONSTRAINT "SitePlan_siteId_fkey" FOREIGN KEY ("siteId") REFERENCES "Site"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
 ALTER TABLE "SitePlan" ADD CONSTRAINT "SitePlan_planId_fkey" FOREIGN KEY ("planId") REFERENCES "Plan"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
 
+-- AddForeignKey
 ALTER TABLE "SiteFeature" ADD CONSTRAINT "SiteFeature_siteId_fkey" FOREIGN KEY ("siteId") REFERENCES "Site"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
 ALTER TABLE "SiteFeature" ADD CONSTRAINT "SiteFeature_featureId_fkey" FOREIGN KEY ("featureId") REFERENCES "Feature"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
 
+-- AddForeignKey
 ALTER TABLE "SiteTheme" ADD CONSTRAINT "SiteTheme_siteId_fkey" FOREIGN KEY ("siteId") REFERENCES "Site"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
 ALTER TABLE "SiteTheme" ADD CONSTRAINT "SiteTheme_themeId_fkey" FOREIGN KEY ("themeId") REFERENCES "Theme"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
 
+-- AddForeignKey
 ALTER TABLE "Payment" ADD CONSTRAINT "Payment_siteId_fkey" FOREIGN KEY ("siteId") REFERENCES "Site"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
 ALTER TABLE "Payment" ADD CONSTRAINT "Payment_sitePlanId_fkey" FOREIGN KEY ("sitePlanId") REFERENCES "SitePlan"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -15,6 +15,18 @@ enum Role {
   USER
 }
 
+enum SitePlanStatus {
+  ACTIVE
+  CANCELED
+  EXPIRED
+}
+
+enum PaymentStatus {
+  PENDING
+  PAID
+  FAILED
+}
+
 model User {
   id        String   @id @default(uuid())
   email     String   @unique
@@ -51,13 +63,13 @@ model Plan {
 }
 
 model Feature {
-  id        String        @id @default(uuid())
-  name      String        @unique
+  id          String        @id @default(uuid())
+  name        String        @unique
   description String?
-  plans     PlanFeature[]
-  sites     SiteFeature[]
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
+  plans       PlanFeature[]
+  sites       SiteFeature[]
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
 }
 
 model PlanFeature {
@@ -66,58 +78,41 @@ model PlanFeature {
   featureId String
   plan      Plan     @relation(fields: [planId], references: [id])
   feature   Feature  @relation(fields: [featureId], references: [id])
-
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
 
   @@index([planId])
   @@index([featureId])
 }
 
-enum SitePlanStatus {
-  ACTIVE
-  CANCELED
-  EXPIRED
-}
-
 model SitePlan {
-  id         String          @id @default(uuid())
-  siteId     String
-  planId     String
-  site       Site            @relation(fields: [siteId], references: [id])
-  plan       Plan            @relation(fields: [planId], references: [id])
-  startedAt  DateTime        @default(now())
-  expiresAt  DateTime?
-  status     SitePlanStatus  @default(ACTIVE)
-  payments   Payment[]
-  createdAt  DateTime        @default(now())
-  updatedAt  DateTime        @updatedAt
-  @@id([planId, featureId])
-  @@index([featureId])
-}
-
-model SitePlan {
-  id        String   @id @default(uuid())
+  id        String         @id @default(uuid())
   siteId    String
   planId    String
-  site      Site     @relation(fields: [siteId], references: [id])
-  plan      Plan     @relation(fields: [planId], references: [id])
-  startDate DateTime @default(now())
-  endDate   DateTime?
-  isActive  Boolean  @default(true)
+  site      Site           @relation(fields: [siteId], references: [id])
+  plan      Plan           @relation(fields: [planId], references: [id])
+  startedAt DateTime       @default(now())
+  expiresAt DateTime?
+  status    SitePlanStatus @default(ACTIVE)
+  payments  Payment[]
+  createdAt DateTime       @default(now())
+  updatedAt DateTime       @updatedAt
+
   @@index([siteId])
   @@index([planId])
 }
 
 model SiteFeature {
-  id        String   @id @default(uuid())
-  siteId    String
-  featureId String
-  site      Site     @relation(fields: [siteId], references: [id])
-  feature   Feature  @relation(fields: [featureId], references: [id])
+  id          String   @id @default(uuid())
+  siteId      String
+  featureId   String
+  site        Site     @relation(fields: [siteId], references: [id])
+  feature     Feature  @relation(fields: [featureId], references: [id])
   activatedAt DateTime @default(now())
-  expiresAt  DateTime?
-  createdAt  DateTime @default(now())
-  updatedAt  DateTime @updatedAt
-  enabledAt DateTime @default(now())
+  expiresAt   DateTime?
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
   @@index([siteId])
   @@index([featureId])
 }
@@ -131,56 +126,36 @@ model Theme {
   sites       SiteTheme[]
   createdAt   DateTime    @default(now())
   updatedAt   DateTime    @updatedAt
-  id        String      @id @default(uuid())
-  name      String
-  description String?
-  sites     SiteTheme[]
-  createdAt DateTime    @default(now())
-  updatedAt DateTime    @updatedAt
-
 }
 
 model SiteTheme {
-  id        String   @id @default(uuid())
-  siteId    String
-  themeId   String
-  site      Site     @relation(fields: [siteId], references: [id])
-  theme     Theme    @relation(fields: [themeId], references: [id])
+  id          String   @id @default(uuid())
+  siteId      String
+  themeId     String
+  site        Site     @relation(fields: [siteId], references: [id])
+  theme       Theme    @relation(fields: [themeId], references: [id])
   activatedAt DateTime @default(now())
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
 
   @@index([siteId])
   @@index([themeId])
 }
 
-
-enum PaymentStatus {
-  PENDING
-  PAID
-  FAILED
-}
-
 model Payment {
-  id             String         @id @default(uuid())
+  id             String        @id @default(uuid())
+  siteId         String
   sitePlanId     String
-  sitePlan       SitePlan       @relation(fields: [sitePlanId], references: [id])
+  site           Site          @relation(fields: [siteId], references: [id])
+  sitePlan       SitePlan      @relation(fields: [sitePlanId], references: [id])
   amount         Float
   currency       String
-  status         PaymentStatus  @default(PENDING)
-  transactionDate DateTime      @default(now())
+  status         PaymentStatus @default(PENDING)
+  transactionDate DateTime     @default(now())
   metadata       Json?
-  createdAt      DateTime       @default(now())
-  updatedAt      DateTime       @updatedAt
-
-  @@index([sitePlanId])
-model Payment {
-  id        String   @id @default(uuid())
-  siteId    String
-  amount    Float
-  currency  String   @default("USD")
-  status    String
-  site      Site     @relation(fields: [siteId], references: [id])
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
+  createdAt      DateTime      @default(now())
+  updatedAt      DateTime      @updatedAt
 
   @@index([siteId])
+  @@index([sitePlanId])
 }

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -5,11 +5,31 @@ const prisma = new PrismaClient();
 
 async function main() {
   const password = await bcrypt.hash('admin123', 10);
-  await prisma.user.create({
+  const admin = await prisma.user.create({
     data: {
       email: 'admin@example.com',
       password,
       role: Role.SUPER_ADMIN,
+    },
+  });
+
+  const basicPlan = await prisma.plan.create({
+    data: {
+      name: 'Basic',
+      price: 0,
+    },
+  });
+
+  await prisma.site.create({
+    data: {
+      name: 'Default Site',
+      ownerId: admin.id,
+      plans: {
+        create: {
+          planId: basicPlan.id,
+          status: 'ACTIVE',
+        },
+      },
     },
   });
 }

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -14,12 +14,8 @@ import { SiteThemeModule } from './site-theme/site-theme.module';
 import { PaymentModule } from './payment/payment.module';
 import { CommerceModule } from './commerce/commerce.module';
 import { AuthModule } from './auth/auth.module';
-import { JwtAuthGuard } from './auth/jwt-auth.guard';
 import { RolesGuard } from './auth/roles.guard';
 import { TenantGuard } from './auth/tenant.guard';
-import { AuthModule } from './auth/auth.module';
-import { JwtAuthGuard } from './auth/jwt-auth.guard';
-import { RolesGuard } from './auth/roles.guard';
 
 
 @Module({
@@ -41,10 +37,8 @@ import { RolesGuard } from './auth/roles.guard';
 
   ],
   providers: [
-    { provide: APP_GUARD, useClass: JwtAuthGuard },
     { provide: APP_GUARD, useClass: RolesGuard },
     { provide: APP_GUARD, useClass: TenantGuard },
-
   ],
 })
 export class AppModule {}

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -3,19 +3,33 @@ import { Request } from 'express';
 import { AuthService } from './auth.service';
 import { JwtAuthGuard } from './jwt-auth.guard';
 import { ApiTags } from '@nestjs/swagger';
+import { Public } from './public.decorator';
+import { LoginDto } from './dto/login.dto';
+import { RegisterDto } from './dto/register.dto';
+import { UserService } from '../user/user.service';
 
 @ApiTags('auth')
 @Controller('auth')
 export class AuthController {
-  constructor(private authService: AuthService) {}
+  constructor(
+    private authService: AuthService,
+    private users: UserService,
+  ) {}
 
+  @Public()
   @Post('login')
-  async login(@Body() body: { email: string; password: string }) {
+  async login(@Body() body: LoginDto) {
     const user = await this.authService.validateUser(body.email, body.password);
     if (!user) {
       throw new Error('Invalid credentials');
     }
     return this.authService.login(user.id);
+  }
+
+  @Public()
+  @Post('register')
+  register(@Body() dto: RegisterDto) {
+    return this.users.create(dto);
   }
 
   @UseGuards(JwtAuthGuard)

--- a/src/auth/dto/login.dto.ts
+++ b/src/auth/dto/login.dto.ts
@@ -1,0 +1,9 @@
+import { IsEmail, MinLength } from 'class-validator';
+
+export class LoginDto {
+  @IsEmail()
+  email: string;
+
+  @MinLength(6)
+  password: string;
+}

--- a/src/auth/dto/register.dto.ts
+++ b/src/auth/dto/register.dto.ts
@@ -1,0 +1,3 @@
+import { CreateUserDto } from '../../user/dto/create-user.dto';
+
+export class RegisterDto extends CreateUserDto {}

--- a/src/auth/jwt-auth.guard.ts
+++ b/src/auth/jwt-auth.guard.ts
@@ -1,5 +1,22 @@
-import { Injectable } from '@nestjs/common';
+import { ExecutionContext, Injectable } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
 import { AuthGuard } from '@nestjs/passport';
+import { IS_PUBLIC_KEY } from './public.decorator';
 
 @Injectable()
-export class JwtAuthGuard extends AuthGuard('jwt') {}
+export class JwtAuthGuard extends AuthGuard('jwt') {
+  constructor(private reflector: Reflector) {
+    super();
+  }
+
+  canActivate(context: ExecutionContext) {
+    const isPublic = this.reflector.getAllAndOverride<boolean>(IS_PUBLIC_KEY, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+    if (isPublic) {
+      return true;
+    }
+    return super.canActivate(context);
+  }
+}

--- a/src/auth/public.decorator.ts
+++ b/src/auth/public.decorator.ts
@@ -1,0 +1,4 @@
+import { SetMetadata } from '@nestjs/common';
+
+export const IS_PUBLIC_KEY = 'isPublic';
+export const Public = () => SetMetadata(IS_PUBLIC_KEY, true);

--- a/src/auth/roles.guard.ts
+++ b/src/auth/roles.guard.ts
@@ -18,6 +18,9 @@ export class RolesGuard implements CanActivate {
     const { user } = context
       .switchToHttp()
       .getRequest<{ user?: { role?: Role } }>();
-    return requiredRoles.includes(user?.role);
+    if (!user?.role) {
+      return false;
+    }
+    return requiredRoles.includes(user.role);
   }
 }

--- a/src/auth/tenant.decorator.ts
+++ b/src/auth/tenant.decorator.ts
@@ -1,0 +1,8 @@
+import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+
+export const Tenant = createParamDecorator(
+  (_: unknown, ctx: ExecutionContext) => {
+    const req = ctx.switchToHttp().getRequest();
+    return req.tenantId as string;
+  },
+);

--- a/src/prisma/prisma.service.ts
+++ b/src/prisma/prisma.service.ts
@@ -1,7 +1,5 @@
 import { Injectable, OnModuleInit, INestApplication } from '@nestjs/common';
 import { PrismaClient } from '@prisma/client';
-import { PrismaClient } from '../../generated/prisma';
-
 
 @Injectable()
 export class PrismaService extends PrismaClient implements OnModuleInit {

--- a/src/site-feature/site-feature.controller.ts
+++ b/src/site-feature/site-feature.controller.ts
@@ -4,48 +4,61 @@ import {
   Post,
   Body,
   Param,
-  Put,
+  Patch,
   Delete,
   Query,
+  UseGuards,
 } from '@nestjs/common';
 import { SiteFeatureService } from './site-feature.service';
 import { CreateSiteFeatureDto } from './dto/create-site-feature.dto';
 import { UpdateSiteFeatureDto } from './dto/update-site-feature.dto';
 import { ApiBearerAuth, ApiTags, ApiOperation } from '@nestjs/swagger';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { Roles } from '../auth/roles.decorator';
+import { Role } from '@prisma/client';
+import { Tenant } from '../auth/tenant.decorator';
 
 @ApiBearerAuth()
+@UseGuards(JwtAuthGuard)
 @ApiTags('site-features')
 @Controller('site-features')
 export class SiteFeatureController {
   constructor(private readonly service: SiteFeatureService) {}
 
   @Post()
+  @Roles(Role.SUPER_ADMIN)
   @ApiOperation({ summary: 'Create site feature' })
-  create(@Body() dto: CreateSiteFeatureDto) {
-    return this.service.create(dto);
+  create(@Body() dto: CreateSiteFeatureDto, @Tenant() tenant: string) {
+    return this.service.create(dto, tenant);
   }
 
   @Get()
   @ApiOperation({ summary: 'List site features' })
-  findAll(@Query('siteId') siteId: string) {
-    return this.service.findAll(siteId);
+  findAll(@Tenant() tenant: string) {
+    return this.service.findAll(tenant);
   }
 
   @Get(':id')
   @ApiOperation({ summary: 'Get site feature' })
-  findOne(@Param('id') id: string) {
-    return this.service.findOne(id);
+  findOne(@Param('id') id: string, @Tenant() tenant: string) {
+    return this.service.findOne(id, tenant);
   }
 
-  @Put(':id')
+  @Patch(':id')
+  @Roles(Role.SUPER_ADMIN)
   @ApiOperation({ summary: 'Update site feature' })
-  update(@Param('id') id: string, @Body() dto: UpdateSiteFeatureDto) {
-    return this.service.update(id, dto);
+  update(
+    @Param('id') id: string,
+    @Body() dto: UpdateSiteFeatureDto,
+    @Tenant() tenant: string,
+  ) {
+    return this.service.update(id, dto, tenant);
   }
 
   @Delete(':id')
+  @Roles(Role.SUPER_ADMIN)
   @ApiOperation({ summary: 'Delete site feature' })
-  remove(@Param('id') id: string) {
-    return this.service.remove(id);
+  remove(@Param('id') id: string, @Tenant() tenant: string) {
+    return this.service.remove(id, tenant);
   }
 }

--- a/src/site-feature/site-feature.service.ts
+++ b/src/site-feature/site-feature.service.ts
@@ -7,31 +7,38 @@ import { UpdateSiteFeatureDto } from './dto/update-site-feature.dto';
 export class SiteFeatureService {
   constructor(private prisma: PrismaService) {}
 
-  create(dto: CreateSiteFeatureDto) {
-    return this.prisma.siteFeature.create({ data: dto });
+  create(dto: CreateSiteFeatureDto, tenant: string) {
+    return this.prisma.siteFeature.create({ data: { ...dto, siteId: tenant } });
   }
 
-  findAll(siteId: string) {
-    return this.prisma.siteFeature.findMany({ where: { siteId } });
+  findAll(tenant: string) {
+    return this.prisma.siteFeature.findMany({ where: { siteId: tenant } });
   }
 
-  async findOne(id: string) {
-    const sf = await this.prisma.siteFeature.findUnique({ where: { id } });
+  async findOne(id: string, tenant: string) {
+    const sf = await this.prisma.siteFeature.findFirst({
+      where: { id, siteId: tenant },
+    });
     if (!sf) throw new NotFoundException('SiteFeature not found');
     return sf;
   }
 
-  async update(id: string, dto: UpdateSiteFeatureDto) {
+  async update(id: string, dto: UpdateSiteFeatureDto, tenant: string) {
     try {
-      return await this.prisma.siteFeature.update({ where: { id }, data: dto });
+      return await this.prisma.siteFeature.update({
+        where: { id, siteId: tenant },
+        data: dto,
+      });
     } catch {
       throw new NotFoundException('SiteFeature not found');
     }
   }
 
-  async remove(id: string) {
+  async remove(id: string, tenant: string) {
     try {
-      return await this.prisma.siteFeature.delete({ where: { id } });
+      return await this.prisma.siteFeature.delete({
+        where: { id, siteId: tenant },
+      });
     } catch {
       throw new NotFoundException('SiteFeature not found');
     }

--- a/src/site-plan/site-plan.controller.ts
+++ b/src/site-plan/site-plan.controller.ts
@@ -4,47 +4,60 @@ import {
   Post,
   Body,
   Param,
-  Put,
+  Patch,
   Delete,
+  UseGuards,
 } from '@nestjs/common';
 import { SitePlanService } from './site-plan.service';
 import { CreateSitePlanDto } from './dto/create-site-plan.dto';
 import { UpdateSitePlanDto } from './dto/update-site-plan.dto';
 import { ApiBearerAuth, ApiTags, ApiOperation } from '@nestjs/swagger';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { Roles } from '../auth/roles.decorator';
+import { Role } from '@prisma/client';
+import { Tenant } from '../auth/tenant.decorator';
 
 @ApiBearerAuth()
+@UseGuards(JwtAuthGuard)
 @ApiTags('site-plans')
 @Controller('site-plans')
 export class SitePlanController {
   constructor(private readonly service: SitePlanService) {}
 
   @Post()
+  @Roles(Role.SUPER_ADMIN)
   @ApiOperation({ summary: 'Create site plan' })
-  create(@Body() dto: CreateSitePlanDto) {
-    return this.service.create(dto);
+  create(@Body() dto: CreateSitePlanDto, @Tenant() tenant: string) {
+    return this.service.create(dto, tenant);
   }
 
   @Get()
   @ApiOperation({ summary: 'List site plans' })
-  findAll() {
-    return this.service.findAll();
+  findAll(@Tenant() tenant: string) {
+    return this.service.findAll(tenant);
   }
 
   @Get(':id')
   @ApiOperation({ summary: 'Get site plan' })
-  findOne(@Param('id') id: string) {
-    return this.service.findOne(id);
+  findOne(@Param('id') id: string, @Tenant() tenant: string) {
+    return this.service.findOne(id, tenant);
   }
 
-  @Put(':id')
+  @Patch(':id')
+  @Roles(Role.SUPER_ADMIN)
   @ApiOperation({ summary: 'Update site plan' })
-  update(@Param('id') id: string, @Body() dto: UpdateSitePlanDto) {
-    return this.service.update(id, dto);
+  update(
+    @Param('id') id: string,
+    @Body() dto: UpdateSitePlanDto,
+    @Tenant() tenant: string,
+  ) {
+    return this.service.update(id, dto, tenant);
   }
 
   @Delete(':id')
+  @Roles(Role.SUPER_ADMIN)
   @ApiOperation({ summary: 'Delete site plan' })
-  remove(@Param('id') id: string) {
-    return this.service.remove(id);
+  remove(@Param('id') id: string, @Tenant() tenant: string) {
+    return this.service.remove(id, tenant);
   }
 }

--- a/src/site-plan/site-plan.service.ts
+++ b/src/site-plan/site-plan.service.ts
@@ -7,34 +7,44 @@ import { UpdateSitePlanDto } from './dto/update-site-plan.dto';
 export class SitePlanService {
   constructor(private prisma: PrismaService) {}
 
-  create(dto: CreateSitePlanDto) {
-    return this.prisma.sitePlan.create({ data: dto });
+  create(dto: CreateSitePlanDto, tenant: string) {
+    return this.prisma.sitePlan.create({
+      data: { ...dto, siteId: tenant },
+    });
   }
 
-  findAll() {
-    return this.prisma.sitePlan.findMany({ include: { payments: true } });
+  findAll(tenant: string) {
+    return this.prisma.sitePlan.findMany({
+      where: { siteId: tenant },
+      include: { payments: true },
+    });
   }
 
-  async findOne(id: string) {
+  async findOne(id: string, tenant: string) {
     const sp = await this.prisma.sitePlan.findUnique({
-      where: { id },
+      where: { id, siteId: tenant },
       include: { payments: true },
     });
     if (!sp) throw new NotFoundException('SitePlan not found');
     return sp;
   }
 
-  async update(id: string, dto: UpdateSitePlanDto) {
+  async update(id: string, dto: UpdateSitePlanDto, tenant: string) {
     try {
-      return await this.prisma.sitePlan.update({ where: { id }, data: dto });
+      return await this.prisma.sitePlan.update({
+        where: { id, siteId: tenant },
+        data: dto,
+      });
     } catch {
       throw new NotFoundException('SitePlan not found');
     }
   }
 
-  async remove(id: string) {
+  async remove(id: string, tenant: string) {
     try {
-      return await this.prisma.sitePlan.delete({ where: { id } });
+      return await this.prisma.sitePlan.delete({
+        where: { id, siteId: tenant },
+      });
     } catch {
       throw new NotFoundException('SitePlan not found');
     }

--- a/src/site/site.controller.ts
+++ b/src/site/site.controller.ts
@@ -6,45 +6,58 @@ import {
   Param,
   Patch,
   Delete,
+  UseGuards,
 } from '@nestjs/common';
 import { SiteService } from './site.service';
 import { CreateSiteDto } from './dto/create-site.dto';
 import { UpdateSiteDto } from './dto/update-site.dto';
 import { ApiTags, ApiBearerAuth, ApiOperation } from '@nestjs/swagger';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { Roles } from '../auth/roles.decorator';
+import { Role } from '@prisma/client';
+import { Tenant } from '../auth/tenant.decorator';
 
 @ApiTags('sites')
 @ApiBearerAuth()
+@UseGuards(JwtAuthGuard)
 @Controller('sites')
 export class SiteController {
   constructor(private readonly siteService: SiteService) {}
 
   @Post()
+  @Roles(Role.SUPER_ADMIN)
   @ApiOperation({ summary: 'Create site' })
-  create(@Body() dto: CreateSiteDto) {
-    return this.siteService.create(dto);
+  create(@Body() dto: CreateSiteDto, @Tenant() tenant: string) {
+    return this.siteService.create(dto, tenant);
   }
 
   @Get()
   @ApiOperation({ summary: 'List sites' })
-  findAll() {
-    return this.siteService.findAll();
+  findAll(@Tenant() tenant: string) {
+    return this.siteService.findAll(tenant);
   }
 
   @Get(':id')
   @ApiOperation({ summary: 'Get site' })
-  findOne(@Param('id') id: string) {
-    return this.siteService.findOne(id);
+  findOne(@Param('id') id: string, @Tenant() tenant: string) {
+    return this.siteService.findOne(id, tenant);
   }
 
   @Patch(':id')
+  @Roles(Role.SUPER_ADMIN)
   @ApiOperation({ summary: 'Update site' })
-  update(@Param('id') id: string, @Body() dto: UpdateSiteDto) {
-    return this.siteService.update(id, dto);
+  update(
+    @Param('id') id: string,
+    @Body() dto: UpdateSiteDto,
+    @Tenant() tenant: string,
+  ) {
+    return this.siteService.update(id, dto, tenant);
   }
 
   @Delete(':id')
+  @Roles(Role.SUPER_ADMIN)
   @ApiOperation({ summary: 'Delete site' })
-  remove(@Param('id') id: string) {
-    return this.siteService.remove(id);
+  remove(@Param('id') id: string, @Tenant() tenant: string) {
+    return this.siteService.remove(id, tenant);
   }
 }

--- a/src/site/site.service.ts
+++ b/src/site/site.service.ts
@@ -7,23 +7,26 @@ import { UpdateSiteDto } from './dto/update-site.dto';
 export class SiteService {
   constructor(private prisma: PrismaService) {}
 
-  create(dto: CreateSiteDto) {
-    return this.prisma.site.create({ data: dto });
+  create(dto: CreateSiteDto, tenantId: string) {
+    return this.prisma.site.create({ data: { ...dto, ownerId: tenantId } });
   }
 
-  findAll() {
-    return this.prisma.site.findMany();
+  findAll(tenantId: string) {
+    return this.prisma.site.findMany({ where: { ownerId: tenantId } });
   }
 
-  findOne(id: string) {
-    return this.prisma.site.findUnique({ where: { id } });
+  findOne(id: string, tenantId: string) {
+    return this.prisma.site.findFirst({ where: { id, ownerId: tenantId } });
   }
 
-  update(id: string, dto: UpdateSiteDto) {
-    return this.prisma.site.update({ where: { id }, data: dto });
+  update(id: string, dto: UpdateSiteDto, tenantId: string) {
+    return this.prisma.site.update({
+      where: { id, ownerId: tenantId },
+      data: dto,
+    });
   }
 
-  remove(id: string) {
-    return this.prisma.site.delete({ where: { id } });
+  remove(id: string, tenantId: string) {
+    return this.prisma.site.delete({ where: { id, ownerId: tenantId } });
   }
 }

--- a/src/user/user.controller.ts
+++ b/src/user/user.controller.ts
@@ -6,21 +6,25 @@ import {
   Param,
   Patch,
   Delete,
+  UseGuards,
 } from '@nestjs/common';
 import { UserService } from './user.service';
 import { CreateUserDto } from './dto/create-user.dto';
 import { UpdateUserDto } from './dto/update-user.dto';
 import { ApiTags, ApiBearerAuth, ApiOperation } from '@nestjs/swagger';
 import { Roles } from '../auth/roles.decorator';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { Role } from '@prisma/client';
 
 @ApiTags('users')
 @ApiBearerAuth()
+@UseGuards(JwtAuthGuard)
 @Controller('users')
 export class UserController {
   constructor(private readonly userService: UserService) {}
 
   @Post()
-  @Roles('SUPER_ADMIN')
+  @Roles(Role.SUPER_ADMIN)
   @ApiOperation({ summary: 'Create user' })
   create(@Body() dto: CreateUserDto) {
     return this.userService.create(dto);
@@ -39,12 +43,14 @@ export class UserController {
   }
 
   @Patch(':id')
+  @Roles(Role.SUPER_ADMIN)
   @ApiOperation({ summary: 'Update user' })
   update(@Param('id') id: string, @Body() dto: UpdateUserDto) {
     return this.userService.update(id, dto);
   }
 
   @Delete(':id')
+  @Roles(Role.SUPER_ADMIN)
   @ApiOperation({ summary: 'Delete user' })
   remove(@Param('id') id: string) {
     return this.userService.remove(id);


### PR DESCRIPTION
## Summary
- clean up prisma schema with proper relations
- add timestamped migration folder
- update PrismaService imports
- configure guards with `@Public` decorator
- add login/register DTOs
- apply role-based access and tenant filtering in site services
- update seed data and environment example

## Testing
- `npm install`
- `npm test` *(fails: Site service spec due to tenantId parameter change)*

------
